### PR TITLE
Update gcs_handler.py to get credentials from environment variable

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,5 +7,5 @@ steps:
       - |
         if [[ "$_TRIGGER_NAME" == "audit-bill-routing" ]]; then
           cd extraction_routing
-          gcloud functions deploy extract-bill-metadata --runtime=python312 --trigger-http --source=. --region=us-central1 --entry-point=extraction_routing;
+          gcloud functions deploy bill-extraction-routing --runtime=python312 --trigger-http --source=. --region=us-central1 --entry-point=extraction_routing --allowUnauthenticated;
         fi

--- a/extraction_routing/methods/gcs_handler.py
+++ b/extraction_routing/methods/gcs_handler.py
@@ -1,6 +1,8 @@
 import datetime
+import os
 
 from google.cloud import secretmanager, storage
+from google.oauth2 import service_account
 
 
 class GCSHandler:
@@ -32,5 +34,13 @@ class GCSHandler:
             expiration=datetime.timedelta(minutes=5),
             # Allow GET requests using this URL.
             method="GET",
+            credentials=self.get_credentials(),
         )
         return signed_url
+
+    def get_credentials(self):
+        """Returns a Google service account credentials object."""
+        credentials = service_account.Credentials.from_service_account_file(
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+        )
+        return credentials


### PR DESCRIPTION
- This change updates the gcs_handler.py file to get the credentials for the service account from the environment variable `GOOGLE_APPLICATION_CREDENTIALS`. 
- This change is necessary because the service account key file is uploaded to the cloud function when it is deployed, and the `get_credentials()` method in the `gcs_handler.py` file uses the `os.environ["GOOGLE_APPLICATION_CREDENTIALS"]` environment variable to get the path to the service account key file.
